### PR TITLE
Redirect for all url types

### DIFF
--- a/redirector/background.js
+++ b/redirector/background.js
@@ -25,7 +25,6 @@ chrome.webRequest.onBeforeRequest.addListener(
     urls: [
       "<all_urls>",
     ],
-    types: ["main_frame"]
   },
   ["blocking"]
 );


### PR DESCRIPTION
The extension would only redirect urls for main_frame resources, but I needed to redirect the background resources of the page, like javascript source urls.  Removing the optional type filter of the event allows the listener to process urls for all types of resources.
